### PR TITLE
5 tc05 check bookmark button

### DIFF
--- a/pages/eco_news_list_page.py
+++ b/pages/eco_news_list_page.py
@@ -13,9 +13,9 @@ class EcoNewsListPage(BasePage):
     SCROLL_PAUSE_TIME = 1
 
     CREATE_NEWS = (By.XPATH, "//div[@id='create-button' and .//span[text()='Create news']]")
-    first_news_on_eco_news_page = '//*[@id="main-content"]/div/div[4]/ul/li[1]/a/app-news-list-gallery-view/div/div/div[2]/div[1]/h3'
     ECO_NEWS_TITLE = (By.XPATH, "//h1[@class='main-header']")
-    BOOKMARK_BUTTON = '//*[@id="main-content"]/div/div[1]/div/div/div[2]'
+    BOOKMARK_BUTTON = '//*[@id="main-content"]/div/div[1]/div/div/div[2]/span'
+    EXPECTED_ACTIV_COLOR = "rgba(19, 170, 87, 1)"
 
     # tag buttons
     NEWS_TAG_BUTTON = '//*[@id="main-content"]/div/div[2]/div/app-tag-filter/div/div/button[1]/a'
@@ -79,10 +79,9 @@ class EcoNewsListPage(BasePage):
                        "EDUCATION": self.EDUCATION_TAG_BUTTON, "INITIATIVES": self.INITIATIVES_TAG_BUTTON,
                        "ADS": self.ADS_TAG_BUTTON}
 
-        expected_activ_color = "rgba(19, 170, 87, 1)"
         element = self.driver.find_element(By.XPATH, tag_to_dict[tag])
         element_color = element.value_of_css_property("background-color")
-        return expected_activ_color == element_color
+        return self.EXPECTED_ACTIV_COLOR == element_color
 
     def get_news_items(self):
         last_height = self.driver.execute_script("return document.body.scrollHeight")
@@ -105,3 +104,8 @@ class EcoNewsListPage(BasePage):
     def click_bookmark_button(self):
         bookmark_button = self.driver.find_element(By.XPATH, self.BOOKMARK_BUTTON)
         bookmark_button.click()
+        self.driver.execute_script('return document.body.innerHTML')
+
+    def news_with_bookmark(self):
+        bookmark = self.driver.find_elements(By.CSS_SELECTOR, ".flag-active")
+        return bookmark

--- a/tests/test_check_bookmark_button.py
+++ b/tests/test_check_bookmark_button.py
@@ -1,0 +1,18 @@
+import pytest
+import time
+from pages.eco_news_list_page import EcoNewsListPage
+
+
+@pytest.mark.check_bookmark_button
+def test_check_bookmark_button(login_driver):
+    page = EcoNewsListPage(login_driver)
+    page.open_page_by_link("https://www.greencity.cx.ua/#/greenCity/news")
+
+    time.sleep(3)
+    page.click_bookmark_button()
+    bookmark_items = len(page.get_news_items())
+    page.click_bookmark_button()
+    count_news_with_bookmark = len(page.news_with_bookmark())
+
+    assert count_news_with_bookmark == bookmark_items
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now bookmark news items directly from the Eco News list.
  * Bookmarked items are clearly flagged with a consistent active state color for easier recognition.
  * The list now accurately reflects the number of bookmarked items.

* **Tests**
  * Added automated coverage to validate the bookmark toggle and the count of flagged items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->