### PR TITLE
test_check_personal_event_icon

### DIFF
--- a/config/resources.py
+++ b/config/resources.py
@@ -2,7 +2,7 @@ from dotenv import load_dotenv
 import os
 
 load_dotenv()
-
+USERNAME = os.getenv("LOCALSTORAGE_name")
 USER_EMAIL = os.getenv("USER_EMAIL")
 USER_PASSWORD = os.getenv("USER_PASSWORD")
 EXPECTED_USERNAME = os.getenv("EXPECTED_USERNAME")

--- a/pages/eco_news_list_page.py
+++ b/pages/eco_news_list_page.py
@@ -15,6 +15,7 @@ class EcoNewsListPage(BasePage):
     CREATE_NEWS = (By.XPATH, "//div[@id='create-button' and .//span[text()='Create news']]")
     ECO_NEWS_TITLE = (By.XPATH, "//h1[@class='main-header']")
     BOOKMARK_BUTTON = '//*[@id="main-content"]/div/div[1]/div/div/div[2]/span'
+    EVENT_ICON_BUTTON = '//*[@id="main-content"]/div/div[1]/div/div/div[3]/img'
     EXPECTED_ACTIV_COLOR = "rgba(19, 170, 87, 1)"
 
     # tag buttons
@@ -26,6 +27,8 @@ class EcoNewsListPage(BasePage):
     # news
     FIRST_NEWS_ON_ECO_NEWS = '//*[@id="main-content"]/div/div[4]/ul/li[1]/a/app-news-list-gallery-view/div/div/div[2]/div[1]/h3'
     NEWS_COUNT_STRING = '//*[@id="main-content"]/div/div[3]/app-remaining-count/div/h2'
+    NEWS_TITLES = "ul[aria-label='news list'] li"
+    NEWS_OWNER = "ul[aria-label='news list'] li p span"
     NEWS_TILES = "ul[aria-label='news list'] li"
 
     first_news_tags_list = '//*[@id="main-content"]/div/div[4]/ul/li[1]/a/app-news-list-gallery-view/div/div/div[1]'
@@ -95,7 +98,7 @@ class EcoNewsListPage(BasePage):
             last_height = new_height
             self.driver.implicitly_wait(10)
 
-        elements = [el for el in self.driver.find_elements(By.CSS_SELECTOR, self.NEWS_TILES) if el.is_displayed()]
+        elements = [el for el in self.driver.find_elements(By.CSS_SELECTOR, self.NEWS_TITLES) if el.is_displayed()]
         self.driver.execute_script("window.scrollTo(0, 0);")
 
         return elements
@@ -109,3 +112,27 @@ class EcoNewsListPage(BasePage):
     def news_with_bookmark(self):
         bookmark = self.driver.find_elements(By.CSS_SELECTOR, ".flag-active")
         return bookmark
+
+    def news_written_by_user(self, user):
+        last_height = self.driver.execute_script("return document.body.scrollHeight")
+
+        while True:
+            self.driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
+            time.sleep(self.SCROLL_PAUSE_TIME)
+            new_height = self.driver.execute_script("return document.body.scrollHeight")
+            if new_height == last_height:
+                break
+            last_height = new_height
+            self.driver.implicitly_wait(10)
+
+        news_written_by_user = [el for el in self.driver.find_elements(By.CSS_SELECTOR, self.NEWS_TILES) if el.is_displayed() and user in el.text]
+
+        self.driver.execute_script("window.scrollTo(0, 0);")
+
+        return news_written_by_user
+
+    def click_event_icon(self):
+        bookmark_button = self.driver.find_element(By.XPATH, self.EVENT_ICON_BUTTON)
+        bookmark_button.click()
+        self.driver.execute_script('return document.body.innerHTML')
+        

--- a/tests/test_check_personal_event_icon.py
+++ b/tests/test_check_personal_event_icon.py
@@ -1,0 +1,15 @@
+import pytest
+from config.resources import USERNAME
+from pages.eco_news_list_page import EcoNewsListPage
+
+
+@pytest.mark.check_personal_event_icon
+def test_check_personal_event_icon(login_driver):
+    page = EcoNewsListPage(login_driver)
+    page.open_page_by_link("https://www.greencity.cx.ua/#/greenCity/news")
+    page.click_tag_filter("EVENTS")
+    count_users_news = len(page.news_written_by_user(USERNAME))
+    page.click_event_icon()
+    count_event_news = page.get_news_items()
+
+    assert count_event_news == count_users_news


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - EcoNews list now supports a personal event filter: click the personal event icon to view only items authored by the signed-in user.
  - Improved detection of news items and author names for more reliable listing and filtering.

- Tests
  - Added automated coverage verifying that the personal event icon correctly filters the EcoNews list to user-authored items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->